### PR TITLE
fix-bug-duplicated-components

### DIFF
--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -14,6 +14,9 @@ const isModuleUnificationProject = require('../module-unification')
   .isModuleUnificationProject;
 /* eslint-enable */
 
+// add more dot files here if you need
+const IGNORED_FILES = ['.DS_Store', '.gitkeep'];
+
 /* eslint-disable ember/no-string-prototype-extensions */
 function updateImportStatements() {
   let importStatements = [];
@@ -66,7 +69,9 @@ function updateImportStatements() {
     fs.readdir(componentsPath, (err, files) => {
       importStatements = files.map((file) => {
         if (file.indexOf('.') > -1) {
-          return `@import "components/${file.split('.')[0]}"\n`;
+          if (!IGNORED_FILES.includes(file)) {
+            return `@import "components/${file.split('.')[0]}"\n`;
+          }
         }
       });
       const importStatementSorted = importStatements.sort().join('');


### PR DESCRIPTION
when generating new components etc.. with ember-cli, blueprint keeps creating duplicated imports inside _components.sass

![Screenshot 2022-11-10 at 16 41 36](https://user-images.githubusercontent.com/18396201/201155537-cea43e20-41a1-46c5-8170-f424e539d0db.png)
